### PR TITLE
feat: support adding llm cache key

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,27 +1,68 @@
+from typing import Literal, TypedDict, Union
+
 from db_conn import get_conn
 
 
-def process_request() -> list[str]:
+class GetRolesRequest(TypedDict, total=False):
+    """Schema for retrieving all LLM cache keys."""
+
+    request_type: Literal["get_roles"]
+
+
+class AddRoleRequest(TypedDict):
+    """Schema for adding a new LLM cache key."""
+
+    request_type: Literal["add_role"]
+    key: str
+
+
+Request = Union[GetRolesRequest, AddRoleRequest]
+
+
+def get_roles() -> list[str]:
+    """Fetch all keys from ``llm_cache_keys``."""
+
     with get_conn() as cursor:
-        cursor.execute('SELECT key FROM llm_cache_keys')
+        cursor.execute("SELECT key FROM llm_cache_keys")
         return [row[0] for row in cursor.fetchall()]
 
-def lambda_handler(event, context):
+
+def add_role(key: str) -> None:
+    """Insert a new key into ``llm_cache_keys``."""
+
+    with get_conn() as cursor:
+        cursor.execute(
+            "INSERT INTO llm_cache_keys (key) VALUES (%s)",
+            (key,),
+        )
+        cursor.connection.commit()
+
+
+def lambda_handler(event: Request, context):
     try:
-        results = process_request()
-        return {
-            'statusCode': 200,
-            'body': results
-        }
+        request_type = event.get("request_type", "get_roles")
+        if request_type == "add_role":
+            key = event.get("key")
+            if not key:
+                return {"statusCode": 400, "body": "Missing key"}
+            add_role(key)
+            body = f"Added key {key}"
+        else:
+            body = get_roles()
+        return {"statusCode": 200, "body": body}
     except Exception as e:
         print(f"Error processing request: {e}")
-        return {
-            'statusCode': 500,
-            'body': 'Internal Server Error'
-        }
+        return {"statusCode": 500, "body": "Internal Server Error"}
+
 
 if __name__ == "__main__":
-    example_event = {}
     example_context = {}
-    result = lambda_handler(example_event, example_context)
-    print(result)
+    example_event_get: GetRolesRequest = {"request_type": "get_roles"}
+    print(lambda_handler(example_event_get, example_context))
+
+    example_event_add: AddRoleRequest = {
+        "request_type": "add_role",
+        "key": "demo-key",
+    }
+    print(lambda_handler(example_event_add, example_context))
+


### PR DESCRIPTION
## Summary
- add typed request schemas for get_roles and add_role
- allow inserting llm cache keys via new add_role request
- dispatch lambda handler based on request type

## Testing
- `python -m py_compile lambda_function.py db_conn.py config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bac53ee6c8320a57a2cfefac8a8d1